### PR TITLE
update-02: update tabulator js and css links

### DIFF
--- a/docs/generate_pages.py
+++ b/docs/generate_pages.py
@@ -20,8 +20,8 @@ template = """
 <html>
 <head>
     <title>{title}</title>
-    <script src="https://unpkg.com/tabulator-tables/dist/js/tabulator.min.js"></script>
-    <link href="https://unpkg.com/tabulator-tables/dist/css/tabulator.min.css" rel="stylesheet">
+    <script src="https://unpkg.com/tabulator-tables@6.3.1/dist/js/tabulator.min.js"></script>
+    <link href="https://unpkg.com/tabulator-tables@6.3.1/dist/css/tabulator.min.css" rel="stylesheet">
     <style>
         #json-table {{ width: 100%; }}
         body {{ font-family: Arial, sans-serif; text-align: center; }}


### PR DESCRIPTION
The older links for the tabulator JS and CSS files are inactive with 520 status code.
The latest version of Tabultor (6.3) files available are at,
https://unpkg.com/tabulator-tables@6.3.1/dist/js/tabulator.min.js
https://unpkg.com/tabulator-tables@6.3.1/dist/css/tabulator.min.css 